### PR TITLE
Remove summary sections from front page and post pages

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -60,12 +60,12 @@ summaryLength = 0
   disableScrollToTop = false
   comments = false
   hidemeta = false
-  hideSummary = false
+  hideSummary = true
   showtoc = false
   tocopen = false
   
   # Persian typography and readability settings
-  ShowPostDescription = true
+  ShowPostDescription = false
   hidePostNavigation = false
 
   [params.cover]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -75,15 +75,7 @@
         </div>
         {{- end }}
         
-        {{/* Post description */}}
-        {{- if (.Param "ShowPostDescription") }}
-        {{- $description := (or .Description .Summary) }}
-        {{- if $description }}
-        <div class="post-description bg-blue-100 border-4 border-black p-6 mt-6 text-right shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transform rotate-[-0.5deg]" style="line-height: 1.75em;">
-          <p class="text-lg text-black font-bold">{{ $description | markdownify }}</p>
-        </div>
-        {{- end }}
-        {{- end }}
+        {{/* Post description section removed */}}
       </header>
 
       {{/* Post Content with Persian typography standards */}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -52,9 +52,7 @@
         {{- end }}
       </h2>
     </header>
-    {{- if (ne (.Param "hideSummary") true) }}
-      <p class="text-black font-medium text-right">{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
-    {{- end }}
+    {{/* Summary section removed */}}
     {{- if not (.Param "hideMeta") }}
     <footer class="entry-footer bg-gray-50 border-2 border-black p-3 shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
       {{- partial "post_meta.html" . -}}


### PR DESCRIPTION
- Remove summary paragraph from homepage (layouts/index.html)
- Remove post description section from single post pages (layouts/_default/single.html)
- Update hugo.toml to disable summaries globally (hideSummary = true, ShowPostDescription = false)

Fixes issue where empty summary paragraphs were appearing in production

🤖 Generated with [Claude Code](https://claude.ai/code)